### PR TITLE
Transfer rules for ref (det)

### DIFF
--- a/apertium-eng-spa.spa-eng.arx
+++ b/apertium-eng-spa.spa-eng.arx
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- nxml -*- -->
+<ref>
+	
+	<section-parameters>
+		<anaphor>
+			<parameter-item has-tags="det pos"/>
+		</anaphor>
+		<antecedent>
+			<parameter-item has-tags="n"/>
+			<parameter-item has-tags="np"/>
+		</antecedent>
+		<delimiter>
+			<parameter-item has-tags="sent"/>
+		</delimiter>
+	</section-parameters>
+
+	<section-def-cats>
+		
+		<def-cat n="det">
+			<cat-item has-tags="det"/>
+			<cat-item has-tags="det pos"/>
+		</def-cat>
+
+		<def-cat n="adj">
+			<cat-item has-tags="adj"/>
+		</def-cat>
+
+		<def-cat n="nom">
+			<cat-item has-tags="n"/>
+			<cat-item has-tags="np"/>
+		</def-cat>
+
+		<def-cat n="np">
+			<cat-item has-tags="np"/>
+		</def-cat>
+
+		<def-cat n="prep">
+      			<cat-item has-tags="pr"/>
+ 	   	</def-cat>
+
+ 	   	<def-cat n="ind">
+    			<cat-item has-tags="ind"/>
+    	</def-cat>
+
+    	<def-cat n="com">
+    		<cat-item has-tags="cm"/>
+    	</def-cat>
+
+	</section-def-cats>
+
+	<section-markables>
+
+		<markable n="PP">
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="det"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="det"/>
+				<pattern-item n="adj"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="det"/>
+				<pattern-item n="adv"/>
+				<pattern-item n="adj"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="det"/>
+				<pattern-item n="preadv"/>
+				<pattern-item n="adj"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="predet"/>
+				<pattern-item n="det"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="predet"/>
+				<pattern-item n="det"/>
+				<pattern-item n="adj"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="predet"/>
+				<pattern-item n="det"/>
+				<pattern-item n="adv"/>
+				<pattern-item n="adj"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="predet"/>
+				<pattern-item n="det"/>
+				<pattern-item n="preadv"/>
+				<pattern-item n="adj"/>
+				<pattern-item n="nom" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="np" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="det"/>
+				<pattern-item n="np" head="t"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="prep"/>
+				<pattern-item n="predet"/>
+				<pattern-item n="det"/>
+				<pattern-item n="np" head="t"/>
+			</pattern>
+
+			<score n="-1"/> <!-- This gives a -1 score to any antecedent that is part of a PP -->
+		</markable>
+
+		<markable n="IP">
+			<pattern>
+				<pattern-item n="ind"/>
+				<pattern-item n="nom"/>
+			</pattern>
+			<pattern>
+				<pattern-item n="ind"/>
+				<pattern-item n="adj"/>
+				<pattern-item n="nom"/>
+			</pattern>
+
+			<score n="-1"/> <!-- This gives a -1 score to any antecedent that is part of a Indefinite Noun Phrase -->
+		</markable>
+
+		<markable n="PNP">
+			<pattern>
+				<pattern-item n="np"/>
+			</pattern>
+
+			<score n="1"/> <!-- This gives a +1 score to any antecedent that is part of a Proper Noun -->
+		</markable>
+
+		<markable n="AdNP"> <!-- NP that is being addressed , for example, "Madam President, ..."-->
+			<pattern>
+				<pattern-item n="nom"/>
+				<pattern-item n="com"/>
+			</pattern>
+
+			<pattern>
+				<pattern-item n="nom"/>
+				<pattern-item n="nom"/>
+				<pattern-item n="com"/>
+			</pattern>
+
+			<score n="-2"/>
+		</markable>
+
+	</section-markables>
+	
+</ref>

--- a/apertium-eng-spa.spa-eng.t1x
+++ b/apertium-eng-spa.spa-eng.t1x
@@ -406,10 +406,6 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
       <cat-item lemma="diciembre" tags="n.m.sg"/>
     </def-cat>
 
-    <def-cat n="det_pos"><!-- anaphora -->
-      <cat-item tags="det.pos.*"/>
-    </def-cat>
-
   </section-def-cats>
   <section-def-attrs>
     <def-attr n="a_nom">

--- a/apertium-eng-spa.spa-eng.t1x
+++ b/apertium-eng-spa.spa-eng.t1x
@@ -652,6 +652,20 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
       <list-item v="pronto"/>
 </def-list>
 
+<def-list n="en_nouns_fem">
+      <list-item v="girl"/>
+      <list-item v="woman"/>
+      <list-item v="daughter"/>
+      <list-item v="sister"/>
+      <list-item v="mother"/>
+      <list-item v="lady"/>
+      <list-item v="wife"/>
+      <list-item v="madam"/>
+      <list-item v="waitress"/>
+      <list-item v="actress"/>
+</def-list>
+
+
   </section-def-lists>
 
 
@@ -3128,7 +3142,15 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
             <let><clip pos="1" side="tl" part="gen"/><lit-tag v="m"/></let>
           </when>
           <when> <!-- Should also check for animacy: la máquina ... el seu ... → the machine ... its ... -->
-            <test><equal><clip pos="1" side="ref" part="gen"/><lit-tag v="f"/></equal></test>
+            <test>
+              <or>
+                <equal><clip pos="1" side="ref" part="gen"/><lit-tag v="f"/></equal>
+                <in>
+                  <clip pos="1" side="ref" part="lem"/>
+                  <list n="en_nouns_fem"/>
+                </in>
+              </or>
+            </test>
             <let><clip pos="1" side="tl" part="lem"/><lit v="her"/></let>
             <let><clip pos="1" side="tl" part="gen"/><lit-tag v="f"/></let>
           </when>

--- a/apertium-eng-spa.spa-eng.t1x
+++ b/apertium-eng-spa.spa-eng.t1x
@@ -3112,8 +3112,8 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
     <when>
       <test><not> <!-- ignore if it's first person, i.e. my or our -->
         <or>
-          <equal><clip pos="1" side="tl" part="lem"/><lit v="my"/></equal>
-          <equal><clip pos="1" side="tl" part="lem"/><lit v="our"/></equal>
+          <equal caseless="yes"><clip pos="1" side="tl" part="lem"/><lit v="my"/></equal>
+          <equal caseless="yes"><clip pos="1" side="tl" part="lem"/><lit v="our"/></equal>
         </or>
       </not></test>
       <choose>

--- a/apertium-eng-spa.spa-eng.t1x
+++ b/apertium-eng-spa.spa-eng.t1x
@@ -3145,7 +3145,7 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
             <test>
               <or>
                 <equal><clip pos="1" side="ref" part="gen"/><lit-tag v="f"/></equal>
-                <in>
+                <in caseless="yes">
                   <clip pos="1" side="ref" part="lem"/>
                   <list n="en_nouns_fem"/>
                 </in>

--- a/apertium-eng-spa.spa-eng.t1x
+++ b/apertium-eng-spa.spa-eng.t1x
@@ -406,6 +406,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
       <cat-item lemma="diciembre" tags="n.m.sg"/>
     </def-cat>
 
+    <def-cat n="det_pos"><!-- anaphora -->
+      <cat-item tags="det.pos.*"/>
+    </def-cat>
+
   </section-def-cats>
   <section-def-attrs>
     <def-attr n="a_nom">
@@ -651,7 +655,6 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
       <list-item v="ya no"/>
       <list-item v="pronto"/>
 </def-list>
-
 
   </section-def-lists>
 
@@ -3108,14 +3111,29 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
    </choose>
  </def-macro>
 
-
+ <def-macro n="ref" npar="1"> <!-- anaphora -->
+      <choose>
+          <when>
+            <test><equal><clip pos="1" side="ref" part="nbr"/><lit-tag v="pl"/></equal></test>
+            <let><clip pos="1" side="tl" part="lem"/><lit v="their"/></let>
+            <let><clip pos="1" side="tl" part="nbr"/><lit-tag v="pl"/></let>
+          </when>
+          <when> <!-- Should also check for animacy: el cotxe ... el seu ... → the car ... its ...  -->
+            <test><equal><clip pos="1" side="ref" part="gen"/><lit-tag v="m"/></equal></test>
+            <let><clip pos="1" side="tl" part="lem"/><lit v="his"/></let>
+            <let><clip pos="1" side="tl" part="gen"/><lit-tag v="m"/></let>
+          </when>
+          <when> <!-- Should also check for animacy: la máquina ... el seu ... → the machine ... its ... -->
+            <test><equal><clip pos="1" side="ref" part="gen"/><lit-tag v="f"/></equal></test>
+            <let><clip pos="1" side="tl" part="lem"/><lit v="her"/></let>
+            <let><clip pos="1" side="tl" part="gen"/><lit-tag v="f"/></let>
+          </when>
+        </choose>
+    </def-macro>
 
   </section-def-macros> 
 
   <section-rules>
-
-
-
 
     <!--*************************************** REGLES DE SN ******************************************** -->
 
@@ -3207,6 +3225,9 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="ant"/>
       </pattern>
       <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>
@@ -3309,6 +3330,9 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="nom"/>
       </pattern>
       <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>
@@ -3542,7 +3566,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="nom"/>
 	<pattern-item n="adj"/>
       </pattern>
-      <action>	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -3740,7 +3767,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="adj"/>
 	<pattern-item n="nom"/>
       </pattern>
-      <action>	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -3873,7 +3903,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="nom"/>
 	<pattern-item n="adj"/>
       </pattern>
-      <action>	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -3944,7 +3977,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="adj"/>
 	<pattern-item n="adj"/>
       </pattern>
-      <action>	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -4058,7 +4094,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="adv_preadv"/>
 	<pattern-item n="adj_pp"/>
       </pattern>
-      <action>	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -4434,7 +4473,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="adj_pp"/>
 	<pattern-item n="nom"/>
       </pattern>
-      <action>	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -4597,7 +4639,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="cnjcoo"/>
 	<pattern-item n="adj"/>
       </pattern>
-      <action>		
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>		
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -4730,7 +4775,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="cnjcoo"/>
 	<pattern-item n="adj"/>
       </pattern>
-      <action>		
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>		
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -4866,7 +4914,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="adv_preadv"/>
 	<pattern-item n="adj"/>
       </pattern>
-      <action>		
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>		
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -5064,7 +5115,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="det"/>
 	<pattern-item n="adj"/>
       </pattern>
-      <action>          	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>          	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>	
@@ -5137,7 +5191,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
 	<pattern-item n="más"/>
 	<pattern-item n="adj_pp"/>
       </pattern>
-      <action>          	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>          	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>
@@ -5235,7 +5292,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
       <pattern>
 	<pattern-item n="det"/>
       </pattern>
-      <action>        	
+      <action>
+  <call-macro n="ref"> <!-- anaphora -->
+    <with-param pos="1"/>
+  </call-macro>        	
 	<call-macro n="firstWord">
 	  <with-param pos="1"/>
 	</call-macro>

--- a/apertium-eng-spa.spa-eng.t1x
+++ b/apertium-eng-spa.spa-eng.t1x
@@ -3108,6 +3108,14 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
  </def-macro>
 
  <def-macro n="ref" npar="1"> <!-- anaphora -->
+  <choose>
+    <when>
+      <test><not> <!-- ignore if it's first person, i.e. my or our -->
+        <or>
+          <equal><clip pos="1" side="tl" part="lem"/><lit v="my"/></equal>
+          <equal><clip pos="1" side="tl" part="lem"/><lit v="our"/></equal>
+        </or>
+      </not></test>
       <choose>
           <when>
             <test><equal><clip pos="1" side="ref" part="nbr"/><lit-tag v="pl"/></equal></test>
@@ -3124,8 +3132,10 @@ Si se quiere empezar a tratar las frase impersonales en el t2x, habría que hace
             <let><clip pos="1" side="tl" part="lem"/><lit v="her"/></let>
             <let><clip pos="1" side="tl" part="gen"/><lit-tag v="f"/></let>
           </when>
-        </choose>
-    </def-macro>
+      </choose>
+    </when>
+  </choose>
+ </def-macro>
 
   </section-def-macros> 
 


### PR DESCRIPTION
Wrote transfer rules that perform modification of a possessive determiner if it has a noun in its ref position, i.e. its antecedent.

Only works for number right now as gender is lost in the target language (English).