### PR TITLE
Add 10 new lexical selection rules

### DIFF
--- a/apertium-eng-spa.eng-spa.dix
+++ b/apertium-eng-spa.eng-spa.dix
@@ -38983,6 +38983,8 @@
     <e><p><l>fire<b/>brigade<s n="n"/></l><r>brigada<g><b/>de<b/>bomberos</g><s n="n"/><s n="f"/></r></p></e>
     <e><p><l>spear<s n="n"/></l><r>lanza<s n="n"/><s n="f"/></r></p></e>
     <e><p><l>eye<b/>shadow<s n="n"/></l><r>sombra<g><b/>de<b/>ojos</g><s n="n"/><s n="f"/></r></p></e>
+    <e a="albertonl" r="LR"><p><l>over<s n="pr"/></l><r>a<b/>lo<b/>largo<b/>de<s n="pr"/></r></p></e>
+    <e a="albertonl" r="LR"><p><l>throughout<s n="pr"/></l><r>a<b/>lo<b/>largo<b/>de<s n="pr"/></r></p></e>
     
   </section>
   <section id="regexp" type="standard">

--- a/apertium-eng-spa.eng-spa.lrx
+++ b/apertium-eng-spa.eng-spa.lrx
@@ -8814,10 +8814,9 @@ convertirse en un personaje de moda o importante. -->
     -->
     <rule weight="1.0">
       <match lemma="alteration" tags="n.*"/>
-      <or>
-        <match lemma="cause" tags="vblex.past.*"/>
-        <match lemma="cause" tags="vblex.pp"/>
-      </or>
+      <match lemma="cause" tags="vblex.past.*">
+      	<select lemma="causar" tags="vblex.ppi.*"/>
+      </match>
       <match lemma="controversy" tags="n.*"/>
     </rule>
     

--- a/apertium-eng-spa.eng-spa.lrx
+++ b/apertium-eng-spa.eng-spa.lrx
@@ -8715,7 +8715,7 @@ convertirse en un personaje de moda o importante. -->
           <match lemma="save" tags="vblex.*"><select lemma="ahorrar" tags="vblex.*"/></match>
           <match lemma="money" tags="n.*"/>
         </rule>
-	
+	  
     <!--
       eng: as part of
       spa: como parte de
@@ -8725,7 +8725,23 @@ convertirse en un personaje de moda o importante. -->
         <select lemma="como" tags="cnjadv"/>
       </match>
       <match lemma="part" tags="n.*"/>
-      <match lemma="of" tags="pr"/>
+      <match lemma="de" tags="pr"/>
+    </rule>
+    
+    <!--
+      eng: archaeological site
+      spa: yacimiento arqueológico
+      (it was translated to 'sitio arqueológico')
+    -->
+    <rule weight="1.0">
+      <or>
+        <match lemma="archaeological" tags="adj"/>
+        <match lemma="geological" tags="adj"/>
+        <match lemma="paleontological" tags="adj"/>
+      </or>
+      <match lemma="site" tags="n.*">
+        <select lemma="yacimiento" tags="n.*"/>
+      </match>
     </rule>
 
     <!--
@@ -8876,23 +8892,23 @@ convertirse en un personaje de moda o importante. -->
     -->
     <rule weight="1.0">
       <match lemma="over" tags="pr">
-        <select lemma="durante" tags="pr"/>
+        <select lemma="a lo largo de" tags="pr"/>
       </match>
       <match lemma="the" tags="det.def.*"/>
       <or>
-        <match lemma="year" tags="n.sg"/>
-        <match lemma="month" tags="n.sg"/>
-        <match lemma="day" tags="n.sg"/>
-        <match lemma="week" tags="n.sg"/>
-        <match lemma="hour" tags="n.sg"/>
-        <match lemma="decade" tags="n.sg"/>
-        <match lemma="century" tags="n.sg"/>
+        <match lemma="year" tags="n.*"/>
+        <match lemma="month" tags="n.*"/>
+        <match lemma="day" tags="n.*"/>
+        <match lemma="week" tags="n.*"/>
+        <match lemma="hour" tags="n.*"/>
+        <match lemma="decade" tags="n.*"/>
+        <match lemma="century" tags="n.*"/>
 
-        <match lemma="summer" tags="n.sg"/>
-        <match lemma="winter" tags="n.sg"/>
-        <match lemma="autumn" tags="n.sg"/>
-        <match lemma="spring" tags="n.sg"/>
-        <match lemma="fall" tags="n.sg"/>
+        <match lemma="summer" tags="n.*"/>
+        <match lemma="winter" tags="n.*"/>
+        <match lemma="autumn" tags="n.*"/>
+        <match lemma="spring" tags="n.*"/>
+        <match lemma="fall" tags="n.*"/>
       </or>
     </rule>
 			

--- a/apertium-eng-spa.eng-spa.lrx
+++ b/apertium-eng-spa.eng-spa.lrx
@@ -8880,19 +8880,19 @@ convertirse en un personaje de moda o importante. -->
       </match>
       <match lemma="the" tags="det.def.*"/>
       <or>
-        <match lemma="year" tags="n.*"/>
-        <match lemma="month" tags="n.*"/>
-        <match lemma="day" tags="n.*"/>
-        <match lemma="week" tags="n.*"/>
-        <match lemma="hour" tags="n.*"/>
-        <match lemma="decade" tags="n.*"/>
-        <match lemma="century" tags="n.*"/>
+        <match lemma="year" tags="n.sg"/>
+        <match lemma="month" tags="n.sg"/>
+        <match lemma="day" tags="n.sg"/>
+        <match lemma="week" tags="n.sg"/>
+        <match lemma="hour" tags="n.sg"/>
+        <match lemma="decade" tags="n.sg"/>
+        <match lemma="century" tags="n.sg"/>
 
-        <match lemma="summer" tags="n.*"/>
-        <match lemma="winter" tags="n.*"/>
-        <match lemma="autumn" tags="n.*"/>
-        <match lemma="spring" tags="n.*"/>
-        <match lemma="fall" tags="n.*"/>
+        <match lemma="summer" tags="n.sg"/>
+        <match lemma="winter" tags="n.sg"/>
+        <match lemma="autumn" tags="n.sg"/>
+        <match lemma="spring" tags="n.sg"/>
+        <match lemma="fall" tags="n.sg"/>
       </or>
     </rule>
 			

--- a/apertium-eng-spa.eng-spa.lrx
+++ b/apertium-eng-spa.eng-spa.lrx
@@ -8847,18 +8847,15 @@ convertirse en un personaje de moda o importante. -->
     </rule>
 
     <!--
-      eng: make concrete
-      spa: hacer hormigón
+      eng: at the time
+      spa: en ese tiempo
     -->
     <rule weight="1.0">
-      <or>
-        <match lemma="make" tags="vblex.*"/>
-        <match lemma="create" tags="vblex.*"/>
-        <match lemma="manufacture" tags="vblex.*"/>
-      </or>
-      <match lemma="concrete" tags="n.*">
-        <select lemma="hormigón" tags="n.*"/>
+      <match lemma="at" tags="pr"/>
+      <match lemma="the" tags="det.def.*">
+      	<select lemma="ese" tags="det.dem.*"/>
       </match>
+      <match lemma="time" tags="n.*"/>
     </rule>
 
 

--- a/apertium-eng-spa.eng-spa.lrx
+++ b/apertium-eng-spa.eng-spa.lrx
@@ -8813,6 +8813,9 @@ convertirse en un personaje de moda o importante. -->
         <match lemma="the" tags="det.def.*"/>
         <match lemma="a" tags="det.ind.*"/>
       </or>
+      <match lemma="article" tags="n.*">
+        <select lemma="artículo" tags="n.*"/>
+      </match>
     </rule>
 
     <!-- 

--- a/apertium-eng-spa.eng-spa.lrx
+++ b/apertium-eng-spa.eng-spa.lrx
@@ -8716,86 +8716,6 @@ convertirse en un personaje de moda o importante. -->
           <match lemma="money" tags="n.*"/>
         </rule>
 	
-	<!--
-    	eng: much of the
-    	spa: gran parte de
-    -->
-    <rule weight="1.0">
-    	<match lemma="much" tags="det.qnt.*">
-    		<select lemma="gran" tags="adj.mf.*"/>
-    	</match>
-    	<match lemma="of" tags="pr">
-    		<select lemma="parte" tags="n.*"/>
-    	</match>
-    	<match lemma="the" tags="det.def.*">
-    		<select lemma="de" tags="pr"/>
-    	</match>
-    </rule>
-
-    <!--
-    	eng: Middle Ages
-      spa: Edad Media (was translated to "Edades Medias")
-    -->
-    <rule weight="1.0">
-      <match lemma="Middle" tags="adj">
-        <select lemma="Edad" tags="n.f.sg"/>
-      </match>
-      <match lemma="Ages" tags="n.*">
-        <select lemma="Media" tags="adj.f.sg"/>
-      </match>
-    </rule>
-    
-    <!--
-      eng: , as [personal pronoun/np] + (was/were) + here/there
-      spa: , ya que [personal pronoun/np] + (estar) + allí/aquí
-    -->
-    <rule weight="1.0">
-      <match tags="cm"/>
-      <match lemma="as" tags="cnjadv">
-        <select lemma="ya que" tags="cnjadv"/>
-      </match>
-      <or>
-        <match tags="prn.subj.*"/>
-        <match tags="np.*"/>
-      </or>
-      <match tags="vbser.past.*">
-        <select lemma="estar" tags="vblex.ppi.*"/>
-      </match>
-      <or>
-        <match lemma="here" tags="adv"/>
-        <match lemma="there" tags="adv"/>
-      </or>
-    </rule>
-    
-    <!--
-      eng: the [ordinal] to [vblex]
-      spa: el [ordinal] en [vblex]
-      example: the first to do the assignment => el primero en hacer la tarea
-    -->
-    <rule weight="1.0">
-      <match lemma="the" tags="det.def.*"/>
-      <match tags="adj.ord"/>
-      <match lemma="to" tags="pr">
-        <select lemma="en" tags="pr"/>
-      </match>
-      <or>
-        <match tags="vblex.*"/>
-        <match tags="vbser.*"/>
-        <match tags="vbhaver.*"/>
-      </or>
-    </rule>
-    
-    <!--
-      eng: document storage
-      spa: almacenamiento de documentos
-    -->
-    <rule weight="1.0">
-      <match lemma="document" tags="n.*">
-        <select lemma="documento" tags="n.m.pl"/>
-      </match>
-      <match lemma="storage" tags="n.*"/>
-    </rule>
-    
     <!--
       eng: as part of
       spa: como parte de
@@ -8807,57 +8727,170 @@ convertirse en un personaje de moda o importante. -->
       <match lemma="part" tags="n.*"/>
       <match lemma="of" tags="pr"/>
     </rule>
-    
+
     <!--
-      eng: alterations caused controversy
-      spa: alteraciones causaron controversia
+      eng: the country's status
+      spa: el estatus del país
     -->
     <rule weight="1.0">
-      <match lemma="alteration" tags="n.*"/>
-      <match lemma="cause" tags="vblex.past.*">
-      	<select lemma="causar" tags="vblex.ppi.*"/>
+      <or>
+        <match lemma="country" tags="n.*"/>
+        <match lemma="nation" tags="n.*"/>
+        <match lemma="state" tags="n.*"/>
+      </or>
+      <match lemma="'s" tags="gen"/>
+      <match lemma="status" tags="n.*">
+        <select lemma="estatus" tags="n.*"/>
       </match>
-      <match lemma="controversy" tags="n.*"/>
     </rule>
-    
+
     <!--
-      eng: focused on ease
-      spa: enfocado en la facilidad
+      eng: global military power
+      spa: potencia militar global
     -->
     <rule weight="1.0">
-      <match lemma="focus" tags="vblex.pp.*"/>
-      <match lemma="on" tags="pr">
-        <select lemma="en" tags="pr"/>
+      <or>
+        <match lemma="global" tags="adj"/>
+        <match lemma="national" tags="adj"/>
+        <match lemma="continental" tags="adj"/>
+        <match lemma="international" tags="adj"/>
+        <match lemma="regional" tags="adj"/>
+      </or>
+      <match lemma="military" tags="adj"/>
+      <match lemma="power" tags="n.*">
+        <select lemma="potencia" tags="n.*"/>
+      </match>
+    </rule>
+
+    <!--
+      eng: socioeconomic performance
+      spa: rendimiento socioeconómico
+    -->
+    <rule weight="1.0">
+      <or>
+        <match lemma="socioeconomic" tags="adj"/>
+        <match lemma="social" tags="adj"/>
+        <match lemma="economic" tags="adj"/>
+        <match lemma="academic" tags="adj"/>
+      </or>
+      <match lemma="performance" tags="n.*">
+        <select lemma="rendimiento" tags="n.*"/>
+      </match>
+    </rule>
+
+    <!--
+      eng: from a letter dated
+      spa: de una carta datada de
+    -->
+    <rule weight="1.0">
+      <or>
+        <match lemma="from" tags="pr"/>
+        <match lemma="of" tags="pr"/>
+        <match lemma="in" tags="pr"/>
+      </or>
+      <match lemma="a" tags="det.ind.*"/>
+      <match lemma="letter" tags="n.*">
+        <select lemma="carta" tags="n.*"/>
       </match>
       <or>
-        <match lemma="ease" tags="n.*"/>
-        <match lemma="dificulty" tags="n.*"/>
+        <match lemma="date" tags="vblex.pp"/>
+        <match lemma="find" tags="vblex.pp"/>
+        <match lemma="write" tags="vblex.pp"/>
+      </or>
+    </rule>
+
+    <!--
+      eng: draft of the article
+      spa: borrador del artículo
+    -->
+    <rule weight="1.0">
+      <or>
+        <match lemma="draft" tags="n.*"/>
+        <match lemma="version" tags="n.*"/> <!-- e.g "final version of the article" -->
+      </or>
+      <match lemma="of" tags="pr"/>
+      <or>
+        <match lemma="the" tags="det.def.*"/>
+        <match lemma="a" tags="det.ind.*"/>
+      </or>
+    </rule>
+
+    <!-- 
+      eng: use the term
+      spa: usar/emplear el término
+    -->
+    <rule weight="1.0">
+      <or>
+        <match lemma="use" tags="vblex.*"/>
+        <match lemma="apply" tags="vblex.*"/>
+        <match lemma="employ" tags="vblex.*"/>
+      </or>
+      <or>
+        <match lemma="the" tags="det.def.*"/>
+        <match lemma="a" tags="det.ind.*"/>
+      </or>
+      <match lemma="term" tags="n.*">
+        <select lemma="término" tags="n.*"/>
+      </match>
+    </rule>
+
+    <!--
+      eng: [prpers/np] appears
+      spa: [prpers/np] aparece
+    -->
+    <rule weight="1.0">
+      <or>
+        <match lemma="prpers" tags="prn.subj.*"/>
+        <match tags="np.*"/>
+      </or>
+      <match lemma="appear" tags="vblex.*">
+        <select lemma="aparecer" tags="vblex.*"/>
+      </match>
+    </rule>
+
+    <!--
+      eng: collection of independent states
+      spa: grupo de estados independientes
+    -->
+    <rule weight="1.0">
+      <match lemma="collection" tags="n.*">
+        <select lemma="grupo" tags="n.*"/>
+      </match>
+      <match lemma="of" tags="pr"/>
+      <match lemma="independent" tags="adj"/>
+      <or>
+        <match lemma="state" tags="n.pl"/>
+        <match lemma="country" tags="n.pl"/>
+        <match lemma="nation" tags="n.pl"/>
+        <match lemma="region" tags="n.pl"/>
+        <match lemma="province" tags="n.pl"/>
       </or>
     </rule>
     
     <!--
-      eng: open-source
-      spa: código abierto
+      eng: over the year
+      spa: durante el año
     -->
     <rule weight="1.0">
-      <match lemma="open" tags="adj.*"/>
-      <match lemma="source" tags="n.*">
-        <select lemma="código" tags="n.*"/>
+      <match lemma="over" tags="pr">
+        <select lemma="durante" tags="pr"/>
       </match>
+      <match lemma="the" tags="det.def.*"/>
+      <or>
+        <match lemma="year" tags="n.*"/>
+        <match lemma="month" tags="n.*"/>
+        <match lemma="day" tags="n.*"/>
+        <match lemma="week" tags="n.*"/>
+        <match lemma="hour" tags="n.*"/>
+        <match lemma="decade" tags="n.*"/>
+        <match lemma="century" tags="n.*"/>
+
+        <match lemma="summer" tags="n.*"/>
+        <match lemma="winter" tags="n.*"/>
+        <match lemma="autumn" tags="n.*"/>
+        <match lemma="spring" tags="n.*"/>
+        <match lemma="fall" tags="n.*"/>
+      </or>
     </rule>
-
-    <!--
-      eng: at the time
-      spa: en ese tiempo
-    -->
-    <rule weight="1.0">
-      <match lemma="at" tags="pr"/>
-      <match lemma="the" tags="det.def.*">
-      	<select lemma="ese" tags="det.dem.*"/>
-      </match>
-      <match lemma="time" tags="n.*"/>
-    </rule>
-
-
 			
 </rules>

--- a/apertium-eng-spa.eng-spa.lrx
+++ b/apertium-eng-spa.eng-spa.lrx
@@ -8715,6 +8715,152 @@ convertirse en un personaje de moda o importante. -->
           <match lemma="save" tags="vblex.*"><select lemma="ahorrar" tags="vblex.*"/></match>
           <match lemma="money" tags="n.*"/>
         </rule>
+	
+	<!--
+    	eng: much of the
+    	spa: gran parte de
+    -->
+    <rule weight="1.0">
+    	<match lemma="much" tags="det.qnt.*">
+    		<select lemma="gran" tags="adj.mf.*"/>
+    	</match>
+    	<match lemma="of" tags="pr">
+    		<select lemma="parte" tags="n.*"/>
+    	</match>
+    	<match lemma="the" tags="det.def.*">
+    		<select lemma="de" tags="pr"/>
+    	</match>
+    </rule>
+
+    <!--
+    	eng: Middle Ages
+      spa: Edad Media (was translated to "Edades Medias")
+    -->
+    <rule weight="1.0">
+      <match lemma="Middle" tags="adj">
+        <select lemma="Edad" tags="n.f.sg"/>
+      </match>
+      <match lemma="Ages" tags="n.*">
+        <select lemma="Media" tags="adj.f.sg"/>
+      </match>
+    </rule>
+    
+    <!--
+      eng: , as [personal pronoun/np] + (was/were) + here/there
+      spa: , ya que [personal pronoun/np] + (estar) + allí/aquí
+    -->
+    <rule weight="1.0">
+      <match tags="cm"/>
+      <match lemma="as" tags="cnjadv">
+        <select lemma="ya que" tags="cnjadv"/>
+      </match>
+      <or>
+        <match tags="prn.subj.*"/>
+        <match tags="np.*"/>
+      </or>
+      <match tags="vbser.past.*">
+        <select lemma="estar" tags="vblex.ppi.*"/>
+      </match>
+      <or>
+        <match lemma="here" tags="adv"/>
+        <match lemma="there" tags="adv"/>
+      </or>
+    </rule>
+    
+    <!--
+      eng: the [ordinal] to [vblex]
+      spa: el [ordinal] en [vblex]
+      example: the first to do the assignment => el primero en hacer la tarea
+    -->
+    <rule weight="1.0">
+      <match lemma="the" tags="det.def.*"/>
+      <match tags="adj.ord"/>
+      <match lemma="to" tags="pr">
+        <select lemma="en" tags="pr"/>
+      </match>
+      <or>
+        <match tags="vblex.*"/>
+        <match tags="vbser.*"/>
+        <match tags="vbhaver.*"/>
+      </or>
+    </rule>
+    
+    <!--
+      eng: document storage
+      spa: almacenamiento de documentos
+    -->
+    <rule weight="1.0">
+      <match lemma="document" tags="n.*">
+        <select lemma="documento" tags="n.m.pl"/>
+      </match>
+      <match lemma="storage" tags="n.*"/>
+    </rule>
+    
+    <!--
+      eng: as part of
+      spa: como parte de
+    -->
+    <rule weight="1.0">
+      <match lemma="as" tags="*">
+        <select lemma="como" tags="cnjadv"/>
+      </match>
+      <match lemma="part" tags="n.*"/>
+      <match lemma="of" tags="pr"/>
+    </rule>
+    
+    <!--
+      eng: alterations caused controversy
+      spa: alteraciones causaron controversia
+    -->
+    <rule weight="1.0">
+      <match lemma="alteration" tags="n.*"/>
+      <or>
+        <match lemma="cause" tags="vblex.past.*"/>
+        <match lemma="cause" tags="vblex.pp"/>
+      </or>
+      <match lemma="controversy" tags="n.*"/>
+    </rule>
+    
+    <!--
+      eng: focused on ease
+      spa: enfocado en la facilidad
+    -->
+    <rule weight="1.0">
+      <match lemma="focus" tags="vblex.pp.*"/>
+      <match lemma="on" tags="pr">
+        <select lemma="en" tags="pr"/>
+      </match>
+      <or>
+        <match lemma="ease" tags="n.*"/>
+        <match lemma="dificulty" tags="n.*"/>
+      </or>
+    </rule>
+    
+    <!--
+      eng: open-source
+      spa: código abierto
+    -->
+    <rule weight="1.0">
+      <match lemma="open" tags="adj.*"/>
+      <match lemma="source" tags="n.*">
+        <select lemma="código" tags="n.*"/>
+      </match>
+    </rule>
+
+    <!--
+      eng: make concrete
+      spa: hacer hormigón
+    -->
+    <rule weight="1.0">
+      <or>
+        <match lemma="make" tags="vblex.*"/>
+        <match lemma="create" tags="vblex.*"/>
+        <match lemma="manufacture" tags="vblex.*"/>
+      </or>
+      <match lemma="concrete" tags="n.*">
+        <select lemma="hormigón" tags="n.*"/>
+      </match>
+    </rule>
 
 
 			


### PR DESCRIPTION
- Rule 1: _much of the_ to be translated to _gran parte de_ instead of _mucho de_ ("fire destroyed much of the complex in 1512" was translated "el fuego destruyó mucho del complejo en 1512").

- Rule 2: _Middle Ages_ to be translated to _Edad Media_ instead of _Edades Medias_ ("[...] strategically important during the Middle Ages" was translated "[...] estratégicamente importante durante las Edades Medias").

- Rule 3: after a comma, _as [prpers/np] [was/were] [here/there]_ to be translated to _ya que [prpers/np] [estar (ppi)] [aquí/allí]_ instead of _como [prpers/np] [ser (prs)] [aquí/allí]_ ("[...] strategically important during the Middle Ages, as it was located [...]" was translated "[...] estratégicamente importante durante las Edades Medias (_see Rule 2_), como esté localizado [...]")

- Rule 4: _the [ordinal] to [verb]_ to be translated to _el [ordinal] en [verb]_ instead of _el [ordinal] para [verb]_ ("the first to include representatives" was translated "el primero para incluir representantes").

- Rule 5: _document storage_ to be translated to _almacenamiento de documentos_ instead of _almacenamiento de documento_.

- Rule 6: _as part of_ to be translated to _como parte de_ instead of _tan parte de_ ("[...] was demolished as part of this work" was translated to "estuvo derribado tan parte de esta obra").

- Rule 7: _alterations caused controversy_ to be translated to _[las] alteraciones causaron controversia_ instead of _alteraciones controversia causada_.

- Rule 8: _focused on ease_ to be translated to _enfocado en [la] facilidad_ instead of _enfocado sobre [la] facilidad_ (also with _difficulty_).

- Rule 9: _open-source_ to be translated to _código abierto_ instead of _fuente abierta_.

- Rule 10: _at the time_ to be translated to _en ese tiempo_ instead of _en el tiempo_.